### PR TITLE
(fix) removing deprecation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Change version number
         id: version
         run: |
-          echo -n "::set-output name=next_tag::"
-          lerna version ${{ github.event.inputs.versionName }} --no-private --no-git-tag-version --yes --no-push
+          next_tag=$(lerna version ${{ github.event.inputs.versionName }} --no-private --no-git-tag-version --yes --no-push)
+          echo "next_tag=$next_tag" >> "$GITHUB_OUTPUT"
       - name: Create pull request into main
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
set-output is deprecated. 

Issue: https://github.com/datavisyn/github-maintenance/issues/18

details about deprecation:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/